### PR TITLE
remove extra rebuild step for linux.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,7 @@ Note: ensure the line ending are CLRF
 6. type `make clean` and `make source` to build Vina-GPU that compile the kernel files on the fly (this would take some time at the first use)
 7. after a successful compiling, `Vina-GPU` can be seen in the directory 
 8. type `./Vina-GPU --config ./input_file_example/2bm2_config.txt` to run Vina-GPU
-9. once you successfully run Vina-GPU, its runtime can be further reduced by typing `make clean` and `make` to build it without compiling kernel files (but make sure the `Kernel2_Opt.bin` file is **unchanged**)
-
-10. other compile options: 
+9. other compile options: 
   
 |Options| Description|
 |--|--|


### PR DESCRIPTION
Removing step 9 from linux installation steps. It was recommended in original implementation but it's not necessary here because this part is already optimized.